### PR TITLE
Fix drizzle initialization for react-native

### DIFF
--- a/src/Drizzle.js
+++ b/src/Drizzle.js
@@ -1,7 +1,10 @@
-// Load as promise so that async Drizzle initialization can still resolve
-var windowPromise = new Promise((resolve, reject) => {
-  window.addEventListener('load', resolve)
-})
+// Check to see if we are running in react-native.
+if !((typeof navigator != 'undefined' && navigator.product == 'ReactNative')) {
+  // Not running in react-native, load as promise so async Drizzle initialization still resolves
+  var windowPromise = new Promise((resolve, reject) => {
+    window.addEventListener('load', resolve)
+  })
+}
 
 class Drizzle {
   constructor(options, store) {
@@ -14,11 +17,19 @@ class Drizzle {
 
     this.loadingContract = {}
 
-    // Wait for window load event in case of injected web3.
-    windowPromise.then(() => {
-      // Begin Drizzle initialization.
+    // Check to see if we are running in react-native.
+    if (typeof navigator != 'undefined' && navigator.product == 'ReactNative') {
+      // Running in react-native, no promise / event to wait for. Begin Drizzle initialization.
       store.dispatch({type: 'DRIZZLE_INITIALIZING', drizzle: this, options})
-    })
+    }   
+    else {
+      // Not running in react-native, wait for window load event in case of injected web3.
+      windowPromise.then(() => {
+        // Begin Drizzle initialization.
+        store.dispatch({type: 'DRIZZLE_INITIALIZING', drizzle: this, options})
+      })
+    }
+    
   }
 
   addContract (contractConfig, events = []) {


### PR DESCRIPTION
React-native does not support async Drizzle initialization via a promise and window.addEventListener, we therefore check to make sure that we are not running in react-native before attempting this. If we are running in react-native we just dispatch the initialize action immediately.

It's probably possible to hook some sort of other event in react-native to allow async loading of Drizzle which would in theory allow for injection of Web3 but I don't know how much sense injection makes in the context of a mobile device.

It's worth noting that currently this code does not mess with Node.JS support in any way but this might also benefit from such a fix.